### PR TITLE
feat: add music model and schema with validation and indexes

### DIFF
--- a/backend/models/music.ts
+++ b/backend/models/music.ts
@@ -1,0 +1,48 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+export interface IMusic extends Document {
+  title: string;
+  artist: string;
+  album?: string;
+  duration: number;
+  genre?: string;
+  fileUrl: string;
+  createdAt: Date;
+}
+
+const MusicSchema: Schema = new Schema({
+  title: {
+    type: String,
+    required: [true, 'Title is required'],
+    trim: true,
+    index: true
+  },
+  artist: {
+    type: String,
+    required: [true, 'Artist is required'],
+    trim: true,
+    index: true
+  },
+  album: {
+    type: String,
+    trim: true
+  },
+  duration: {
+    type: Number,
+    required: true
+  },
+  genre: {
+    type: String,
+    trim: true
+  },
+  fileUrl: {
+    type: String,
+    required: true,
+    unique: true
+  }
+}, {
+
+  timestamps: { createdAt: true, updatedAt: false }
+});
+
+export default mongoose.model<IMusic>('Music', MusicSchema);


### PR DESCRIPTION
Hi! I have implemented the Music model and MongoDB schema as requested in issue #48. I've used TypeScript for type safety, enabled schema validation, and added indexes for title and artist fields for better performance.