### PR TITLE
docs: atualizar README com instruções e limpeza

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,36 @@
 # 🌙 NightMusic
 
-NightMusic é um projeto de estudo fullstack com foco em evolução incremental: uma interface Next.js para autenticação/player e um backend Express simples para rotas de API.
+NightMusic é um projeto de estudo fullstack com foco em evolução incremental: uma interface em Next.js para autenticação/player e uma API em Express para suportar funcionalidades de música e playlists.
 
 > Status atual: **protótipo funcional para desenvolvimento local**, com autenticação mock e playlists de exemplo.
 
 ---
 
-## ✨ O que já existe hoje
+## ✨ Funcionalidades atuais
 
 ### Frontend (Next.js)
 
 - Fluxo de autenticação com telas de **login**, **registro** e **recuperação de senha**.
 - Login mock via `/api/auth/login` com persistência de token em `localStorage` (`nm_token`).
 - Área autenticada em `/dashboard` com navegação entre playlists mockadas.
-- Player principal em `/` com upload local de arquivos de áudio (via `blob URL`) e controles básicos (play, pause, anterior, próximo).
+- Player principal em `/` com upload local de áudio (via `blob URL`) e controles básicos (play, pause, anterior, próximo).
 
 ### Backend (Express + TypeScript)
 
-- Servidor com middleware de log e tratamento global de erros.
-- Endpoints:
+- Middleware de log e tratamento global de erros.
+- Endpoints disponíveis:
   - `GET /health` → healthcheck
   - `GET /musics` → resposta simples da API
-  - `GET /api/error-test` → rota para validar handler de erro
+  - `GET /api/error-test` → rota para validar o handler de erro
 
 ---
 
 ## 🧱 Stack
 
-- **Frontend:** Next.js 16, React 19, TypeScript, CSS/Tailwind (dependências instaladas)
+- **Frontend:** Next.js 16, React 19, TypeScript
 - **Backend:** Node.js, Express 5, TypeScript
-- **Tooling:** Prettier
+- **Estilos:** CSS global + Tailwind (dependências instaladas)
+- **Tooling:** Prettier + Oráculo CLI
 
 ---
 
@@ -67,24 +68,24 @@ npm install
 npm run dev
 ```
 
-### 3) Subir o backend (porta 3000)
+### 3) Subir o backend
 
 ```bash
 npm run backend:dev
 ```
 
-> O frontend usa rewrites para encaminhar `/musics/*` e `/api/*` para `http://localhost:3000`.
+> Se ocorrer erro relacionado ao caminho `backend/src/server.ts`, atualize o script `backend:dev` no `package.json` para apontar para `backend/server.ts`.
 
 ---
 
-## 🔐 Credenciais de desenvolvimento
+## 🔐 Credenciais de desenvolvimento (mock)
 
 Para testar login no estado atual:
 
 - **Usuário:** `user`
 - **Senha:** `password`
 
-Ao autenticar, o token mock é salvo no navegador (`localStorage`) e o usuário é redirecionado para `/dashboard`.
+Ao autenticar, o token mock é salvo no navegador e o usuário é redirecionado para `/dashboard`.
 
 ---
 
@@ -97,33 +98,28 @@ npm run start            # start do build frontend
 npm run backend:dev      # backend express em modo dev
 npm run backend:build    # build TypeScript geral
 npm run backend:start    # start backend compilado
-```
-
-Também existem scripts de apoio para o Oráculo:
-
-```bash
-npm run diagnosticar
-npm run formatar
-npm run otimizar
+npm run diagnosticar     # inspeções do Oráculo
+npm run formatar         # formatação automática
+npm run otimizar         # otimização de SVGs
 ```
 
 ---
 
 ## ⚠️ Limitações conhecidas
 
-- Autenticação é **mock** (não há usuário real, JWT real, refresh token ou sessão segura).
-- Playlists do dashboard ainda são dados fixos em memória.
-- Upload de música na página principal depende de `blob:` URL e não persiste após recarregar.
-- Existem artefatos legados (ex.: pasta `app/pages`) convivendo com App Router.
+- Autenticação ainda é **mock** (sem JWT real, refresh token ou sessão persistente segura).
+- Playlists do dashboard permanecem em dados fixos.
+- Upload da página principal usa `blob:` URL e não persiste após recarregar.
+- Projeto ainda possui partes legadas (ex.: `app/pages`) coexistindo com App Router.
 
 ---
 
-## 🛣️ Próximos passos
+## 🛣️ Próximos passos sugeridos
 
 - Integrar autenticação real (cadastro, login, recuperação de senha).
 - Persistir playlists/músicas em banco de dados.
-- Unificar totalmente a arquitetura em App Router.
-- Expandir API backend para operações CRUD de playlists e faixas.
+- Consolidar totalmente a arquitetura em App Router.
+- Expandir a API backend para CRUD de playlists e faixas.
 
 ---
 
@@ -135,19 +131,12 @@ MIT.
 
 Eduardo B.
 
-This project is part of a personal learning journey into backend and fullstack development.
+Parte da jornada pessoal de aprendizado em backend e fullstack.
 
-<!-- Status badges -->
+---
+
+## 🔖 Badges
 
 [![Build Status](https://github.com/eduardo-balbino/NightMusic/actions/workflows/build.yml/badge.svg)](https://github.com/eduardo-balbino/NightMusic/actions/workflows/build.yml)
-[![Website Status](https://img.shields.io/website?down_color=red&down_message=down&up_message=up&url=https://galeria-drab.vercel.app)](https://galeria-drab.vercel.app)
-
-<!-- Badges do site pessoal: autor, licença, deploy e framework -->
-
 [![Deployed on Vercel](https://img.shields.io/badge/deployed%20on-Vercel-000000?style=flat&logo=vercel)](https://vercel.com)
-[function greet(name: string): string {
-  return `Hello, ${name}!`;
-}
-
-const message: string = greet("World");
-console.log(message);![Built with Next.js](https://img.shields.io/badge/Framework-Next.js-black?logo=next.js)](https://nextjs.org)
+[![Built with Next.js](https://img.shields.io/badge/Framework-Next.js-black?logo=next.js)](https://nextjs.org)


### PR DESCRIPTION
### Motivation
- Atualizar e reorganizar o `README.md` para refletir o estado atual do projeto e reduzir confusão no setup local.
- Remover trecho inválido/corrompido que estava no final do arquivo e padronizar linguagem em português.
- Tornar as instruções de execução e scripts mais claras, incluindo um aviso sobre o script `backend:dev` e o possível caminho do servidor.

### Description
- Reescreve a introdução e reorganiza seções de funcionalidades, stack, estrutura e execução local no `README.md`.
- Remove trecho de código corrompido no final do arquivo e padroniza as seções de badges, licença e autor.
- Ajusta e consolida a lista de scripts úteis, adiciona observação para atualizar `backend:dev` caso o caminho do servidor difira, e harmoniza vocabulário (por exemplo, marcação de auth como mock).
- Mantém e reorganiza badges úteis e a descrição da estrutura do projeto para facilitar onboarding.

### Testing
- Executado `npm run build` (Next.js `next build`) que compilou com sucesso e gerou as páginas estáticas/rotas esperadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4108681a88324b1f761e3a652347d)